### PR TITLE
[LO-408] Remove font-weight: 100 property

### DIFF
--- a/style/font.scss
+++ b/style/font.scss
@@ -4,10 +4,8 @@
 /* Define Fonts for Elements */
 .lto-label {
   font-family: Roboto, Helvetica, sans-serif;
-  font-weight: 100;
 }
 
 text {
   font-family: Montserrat, Helvetica, sans-serif;
-  font-weight: 100;
 }


### PR DESCRIPTION
This font-weight property makes texts look a little too thin, now they look normal again.

(Da ich das jetzt schon zwei mal bei neuen Ableitungen gemacht hab kann es gleich hier geändert werden.)